### PR TITLE
Ability to mention the calculator channel instead of just hard coding it

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,21 @@ Keep in mind that this calculation is an estimate. Your actual block rewards can
     ```
 
 3. Configure the bot:
-    - Open the `bot.py` file.
-    - Replace `'X'` with your Discord bot token.
-    - Replace the `CATEGORY_ID`, `ROLE_ID`, `MEMBER_COUNT_CHANNEL_ID`, and `BOT_LOG_CHANNEL_ID` with your actual IDs.
+    - Rename the ``example.env`` to ``.env``.
+    - Open ``.env`` file with any text editor.
+    ```
+    TOKEN= # Bot Token
+    CATEGORY_ID= # Category ID
+    ROLE_ID= # Role ID
+    MEMBER_COUNT_CHANNEL_ID= # Member Count Channel ID
+    BOT_LOG_CHANNEL_ID= # Bot Log Channel ID
+    GUILD_ID= # Guild ID
+    COMMAND_CHANNEL_ID= # Command Channel ID
+    ACCOUNT_AGE_LIMIT=3 # Account Age Limit
+    SPAM_THRESHOLD=3 # Spam Threshold
+    ```
+    - Fill in your bot token next to the ``=`` sign in the first line.
+    - Fill in the `CATEGORY_ID`, `ROLE_ID`, `MEMBER_COUNT_CHANNEL_ID`, and `BOT_LOG_CHANNEL_ID` with your actual IDs.
 
 4. Run the bot:
     ```sh

--- a/bot.py
+++ b/bot.py
@@ -339,7 +339,7 @@ async def get_market_cap():
 @bot.command(name='calc')
 async def calc(ctx, hashrate: float = None):
     if ctx.channel.id != COMMAND_CHANNEL_ID:
-        await ctx.send(f"This command can only be used in the ⛏︱calculator channel.")
+        await ctx.send(f"This command can only be used in the <#1250496462819950667> channel.")
         return
     
     if hashrate is None:

--- a/example.env
+++ b/example.env
@@ -1,0 +1,9 @@
+TOKEN= # Bot Token
+CATEGORY_ID= # Category ID
+ROLE_ID= # Role ID
+MEMBER_COUNT_CHANNEL_ID= # Member Count Channel ID
+BOT_LOG_CHANNEL_ID= # Bot Log Channel ID
+GUILD_ID= # Guild ID
+COMMAND_CHANNEL_ID= # Command Channel ID
+ACCOUNT_AGE_LIMIT=3 # Account Age Limit
+SPAM_THRESHOLD=3 # Spam Threshold


### PR DESCRIPTION
Hi, this feature is a very slight improvement that just helps the new discord users
- Removed hard coded calculator channel name inside the code, which in the future if the channel name is changed, it gets dynamically updated as its the channel ID thats used to mention the channel. Users can now click on the channel thats mentioned and directly go to the calculator channel!

(Edit)
- Users are now able to use slash commands instead of normal commands.
- The bot updates its game status for fun (related to spectre community)
- Uses ENV variables instead of hardcoded variables inside the python file
- README file changes

Ill be doing some more contributions to the spectre project, its very interesting and newly born bud among all other cryptocurrencies with new intensions and ideas!